### PR TITLE
explicitly cast 'slide' arg of toSlide() to an integer

### DIFF
--- a/js/jquery.plusslider.js
+++ b/js/jquery.plusslider.js
@@ -109,7 +109,7 @@
                     
                     } else {
 
-                        base.currentSlideIndex = slide;
+                        base.currentSlideIndex = parseInt(slide);
 
                     }
                     // End Handling of slide values


### PR DESCRIPTION
Fixed bug that occurs when you call toSlide from outside the slider and pass it a number-as-a-string (for example, I was pulling the slide index from an html attribute on my custom pagination controls, using the jquery .attr() function, which returns the attribute as a string, even though it's a number). Without explicitly casting the slide to an integer, the _next_ time toSlide() is run the base.currentSlideIndex += 1 does a string concatenation (e.g. "01" or "12" or "23" etc.) instead of addition.
